### PR TITLE
Use virtual-hosted–style URL

### DIFF
--- a/s3.sh
+++ b/s3.sh
@@ -3,7 +3,7 @@
 s3_url() {
   local bucket=${1}
   local path=${2}
-  local url="http://s3.amazonaws.com/${bucket}/${path}"
+  local url="http://${bucket}.s3.amazonaws.com/${path}"
 
   echo ${url}
 }


### PR DESCRIPTION
Host s3.amazonaws.com points by default to US East (N. Virginia).

Thus, if no region is specified in the URL, one is getting this error message :

> 
<Message>The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.</Message>

http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro
