### PR TITLE
Signed URL by temporary credentials from an IAM role

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ s3_signed_url ${httpMethod} ${bucket} ${path} ${awsKey} ${awsSecret} ${expires:-
 
 Returns a signed url, suitable for making requests to a private s3 object.
 
+```bash
+role_name="my_role"
+temporary_creds=$(curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/${role_name})
+awsKey=$(echo ${temporary_creds} | jq -r '.AccessKeyId')
+awsSecret=$(echo ${temporary_creds} | jq -r '.SecretAccessKey')
+awsToken=$(echo ${temporary_creds} | jq -r '.Token'))
+s3_signed_url ${httpMethod} ${bucket} ${path} ${awsKey} ${awsSecret} ${expires:-$((`date +%s`+60))} ${awsToken}
+```
+
+Returns a signed url by credentials provided by an IAM role
+
 Dependencies:
 
 * date, if ${expires} parameter is not provided


### PR DESCRIPTION
Generation of a signed URL by temporary credentials provided by an IAM role

Uses case might be scarce as the provided credentials are only valid for 6 hours from the moment they have been generated by AWS : https://forums.aws.amazon.com/thread.jspa?threadID=153786

This PR may probably not be merged but, well we passed half a day working on this so I'd like to share this here though in case it could be be helpful for some people one day.
